### PR TITLE
[SparseTIR] Hack `IsAffineBinding` check

### DIFF
--- a/include/tvm/tir/schedule/state.h
+++ b/include/tvm/tir/schedule/state.h
@@ -162,6 +162,13 @@ class ScheduleStateNode : public Object {
    * \return A boolean flag indicating if the block has quasi-affine bindings
    */
   bool IsAffineBlockBinding(const StmtSRef& block_sref) const {
+    // (SparseTIR Hack) Always return true for sparse blocks.
+    const auto* block = block_sref->StmtAs<BlockNode>();
+    Optional<ObjectRef> sparse_attr = block != nullptr ? block->annotations.Get("sparse") : NullOpt;
+    if (sparse_attr.defined() && sparse_attr.as<IntImmNode>()->value == 1) {
+      return true;
+    }
+
     return GetBlockInfo(block_sref).affine_binding;
   }
   /*!

--- a/src/tir/schedule/primitive/reduction.cc
+++ b/src/tir/schedule/primitive/reduction.cc
@@ -212,6 +212,7 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
   ObjectPtr<BlockNode> init_block = make_object<BlockNode>();
   ObjectPtr<BlockRealizeNode> init_realize = make_object<BlockRealizeNode>();
   init_block->name_hint = block->name_hint + "_init";
+  init_block->annotations = block->annotations;
   init_realize->iter_values = {};
   init_realize->block = Block(init_block);
   // Step 1. Create new block vars and their bindings
@@ -580,7 +581,10 @@ class BaseBlockCreator {
         /*body=*/new_reduction_update_,
         /*init=*/
         BufferStore(new_reduction_update_->buffer, reducer_->identity_element[0],
-                    new_reduction_update_->indices));
+                    new_reduction_update_->indices),
+        /*alloc_buffers=*/{},
+        /*match_buffers=*/{},
+        /*annotations=*/old_block_realize_->block->annotations);
     new_block_realize_ = BlockRealize(iter_values_, predicate, new_block_);
   }
 

--- a/tests/python/sparsetir/test_tir_sparse_correctness.py
+++ b/tests/python/sparsetir/test_tir_sparse_correctness.py
@@ -267,10 +267,9 @@ def test_sddmm():
     )
     blk = sch.get_block("sddmm")
     ij, k = sch.get_loops(blk)
-    # TODO(zihao): fix the behavior in the future.
-    # sch.decompose_reduction(blk, ij)
     sch.bind(ij, "blockIdx.x")
     sch.bind(k, "threadIdx.x")
+    sch.decompose_reduction(blk, k)
 
     # convert numpy tensor to tvm ndarray
     C_indices = tvm.nd.array(indices.astype("int32"), device=tvm.cuda(0))


### PR DESCRIPTION
This PR hacks the `IsAffineBinding` check according to the "sparse" block annotation.

Now the SDDMM correctness check is runnable and can pass!

cc @yzh119 